### PR TITLE
Fix sparsity ans smoothness in loss function. Save bandwidth and training time by preprocessing dataset

### DIFF
--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -7,7 +7,7 @@ import option
 args=option.parse_args()
 
 class Dataset(data.Dataset):
-    def __init__(self, args, is_normal=True, transform=None, test_mode=False):
+    def __init__(self, args, is_normal=True, transform=None, test_mode=False, is_preprocessed=False):
         self.modality = args.modality
         self.is_normal = is_normal
         if test_mode:
@@ -66,6 +66,8 @@ class Dataset(data.Dataset):
             return features, name
         else:
             if args.datasetname == 'UCF':
+                if self.is_preprocessed:
+                    return features,label
                 features = features.transpose(1, 0, 2)  # [10, T, F]
                 divided_features = []
 

--- a/train.py
+++ b/train.py
@@ -9,13 +9,11 @@ def sparsity(arr, batch_size, lamda2):
     loss = torch.mean(torch.norm(arr, dim=0))
     return lamda2*loss
 
-
 def smooth(arr, lamda1):
-    arr2 = torch.zeros_like(arr)
-    arr2[:-1] = arr[1:]
-    arr2[-1] = arr[-1]
+    arr1 = arr[:,:-1,:]
+    arr2 = arr[:,1:,:]
 
-    loss = torch.sum((arr2-arr)**2)
+    loss = torch.sum((arr2-arr1)**2)
 
     return lamda1*loss
 
@@ -72,6 +70,7 @@ class mgfn_loss(torch.nn.Module):
         loss_con_a = self.contrastive(torch.norm(abn_feamagnitude[int(seperate):], p=1, dim=2),
                                       torch.norm(abn_feamagnitude[:int(seperate)], p=1, dim=2), 0)
         loss_total = loss_cls + 0.001 * (0.001 * loss_con + loss_con_a + loss_con_n )
+        
         return loss_total
 
 
@@ -85,25 +84,25 @@ def train(nloader, aloader, model, batch_size, optimizer, device,iterator = 0):
             input = torch.cat((ninput, ainput), 0).to(device)
 
             score_abnormal, score_normal, abn_feamagnitude, nor_feamagnitude, scores = model(input)  # b*32  x 2048
-            scores = scores.view(batch_size * 32 * 2, -1)
+            
+            loss_sparse = sparsity(scores[:batch_size,:,:].view(-1), batch_size, 8e-3)
+            
+            loss_smooth = smooth(scores,8e-4)
 
+            scores = scores.view(batch_size * 32 * 2, -1)
             scores = scores.squeeze()
-            abn_scores = scores[batch_size * 32:]
 
             nlabel = nlabel[0:batch_size]
             alabel = alabel[0:batch_size]
 
             loss_criterion = mgfn_loss(0.0001)
-            loss_sparse = sparsity(abn_scores, batch_size, 8e-3)
-            loss_smooth = smooth(abn_scores, 8e-4)
 
             cost = loss_criterion(score_normal, score_abnormal, nlabel, alabel, nor_feamagnitude, abn_feamagnitude) + loss_smooth + loss_sparse
-
 
             optimizer.zero_grad()
             cost.backward()
 
             optimizer.step()
             iterator += 1
-        return  cost.item(),loss_smooth.item(),loss_sparse.item()
 
+        return  cost.item(),loss_smooth.item(),loss_sparse.item()


### PR DESCRIPTION
- Sparsity should be norm of normal scores as they are intended to be small and not abnormal scores as was done in initial implementation.
- Smoothness should only pertain to one video and initial implementation leaked in other videos as well
- Dataset can be preprocessed to save bandwidth and training time: 
https://drive.google.com/drive/folders/1TfqCWvG3N2fqmiPIRuEkl_s2mNmbkRwN?usp=sharing 